### PR TITLE
Adjustment to enable set MESSAGE_COUNT when also setting THREAD_COUNT

### DIFF
--- a/src/main/java/dev/nipafx/lab/loom/echo/client/Send.java
+++ b/src/main/java/dev/nipafx/lab/loom/echo/client/Send.java
@@ -61,7 +61,7 @@ public class Send {
 			if (args.length == 0)
 				throw new IllegalArgumentException("Please specify the implementation.");
 			var implementation = Threading.valueOf(args[0].toUpperCase());
-			var messageCount = args.length == 2 ? Integer.parseInt(args[1]) : DEFAULT_MESSAGE_COUNT;
+			var messageCount = args.length >= 2 ? Integer.parseInt(args[1]) : DEFAULT_MESSAGE_COUNT;
 			var threadCount = args.length == 3 ? Integer.parseInt(args[2]) : DEFAULT_THREAD_COUNT;
 			return new Configuration(implementation, messageCount, threadCount);
 		}


### PR DESCRIPTION
The way it was implemented, if we also SET THREAD_COUNT than MESSAGE_COUNT always set to default value.

By the way, I really appreciate this repo. 