### PR TITLE
fix: jdk.incubator.concurrent module removed from java packages

### DIFF
--- a/experiments/pom.xml
+++ b/experiments/pom.xml
@@ -33,6 +33,15 @@
 					<finalName>loom-experiments</finalName>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>21</source>
+					<target>21</target>
+					<compilerArgs>--enable-preview</compilerArgs>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/experiments/pom.xml
+++ b/experiments/pom.xml
@@ -11,7 +11,7 @@
 		<groupId>dev.nipafx.lab.loom</groupId>
 		<artifactId>aggregator</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<properties>

--- a/experiments/src/main/java/dev/nipafx/lab/loom/crawl/crawler/PageTreeFactory.java
+++ b/experiments/src/main/java/dev/nipafx/lab/loom/crawl/crawler/PageTreeFactory.java
@@ -37,7 +37,7 @@ public class PageTreeFactory {
 		System.out.printf("Resolving '%s'...%n", url);
 		var pageWithLinks = fetchPageWithLinks(url);
 		var page = pageWithLinks.page();
-		resolvedPages.computeIfAbsent(page.url(), __ -> page);
+		resolvedPages.putIfAbsent(page.url(), page);
 		System.out.printf("Resolved '%s' with children: %s%n", url, pageWithLinks.links());
 
 		if (page instanceof GitHubPage ghPage) {

--- a/experiments/src/main/java/module-info.java
+++ b/experiments/src/main/java/module-info.java
@@ -1,7 +1,4 @@
 module loom.experiments {
-	// for virtual thread / structured concurrency APIs
-	requires jdk.incubator.concurrent;
-
 	// unrelated
 	requires java.net.http;
 	requires java.desktop;


### PR DESCRIPTION
fixed project not compiling due to jdk.incubator.concurrent being integrated into java.utils.concurrent